### PR TITLE
indexed MyDatePickerModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install this component to an external project, follow the procedure:
 
 1. Make sure you're using Webpack and have installed `raw-loader`, `postcss-loader` and `sass-loader`.
 2. `npm install angular2-datepicker`.
-3. `import {MyDatePickerModule} from 'mydatepicker/src/my-date-picker/my-date-picker.module';`
+3. `import {MyDatePickerModule} from 'mydatepicker';`
 4. import Datepicker module
 ```
 @NgModule({

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { MyDatePickerModule } from './src/my-date-picker/my-date-picker.module';


### PR DESCRIPTION
importing the module from `mydatepicker` is more practical than importing from `mydatepicker/src/my-date-picker/my-date-picker.module`. So that an index file added.